### PR TITLE
Add repos mirror periodic job

### DIFF
--- a/.github/workflows/repos-mirror.yml
+++ b/.github/workflows/repos-mirror.yml
@@ -1,0 +1,24 @@
+name: MindSpore Gitee repos mirror periodic job
+
+on:
+  pull_request:
+    # Runs at every pull requests submitted in master branch 
+    branches: [ master ]
+  schedule:
+    # Runs at 01:00 UTC (9:00 AM Beijing) every day
+    - cron:  '0 1 * * *'
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Mirror the gitee/mindspore org repos to github/mindspore-ai.
+      uses: Yikun/hub-mirror-action@v0.04
+      with:
+        src: gitee/mindspore
+        dst: github/mindspore-ai
+        dst_key: ${{ secrets.SYNC_MINDSPORE_PRIVATE_KEY }}
+        dst_token:  ${{ secrets.SYNC_MINDSPORE_TOKEN }}
+        account_type: org


### PR DESCRIPTION
This patch adds the repo mirror workflow to mirror the repo from gitee to github.

This action will executed in every pull request and 01:00 UTC (9:00 AM Beijing) every day.