### PR TITLE
Remove the PR triggered event

### DIFF
--- a/.github/workflows/repos-mirror.yml
+++ b/.github/workflows/repos-mirror.yml
@@ -1,9 +1,6 @@
 name: MindSpore Gitee repos mirror periodic job
 
 on:
-  pull_request:
-    # Runs at every pull requests submitted in master branch 
-    branches: [ master ]
   schedule:
     # Runs at 01:00 UTC (9:00 AM Beijing) every day
     - cron:  '0 1 * * *'


### PR DESCRIPTION
The mindspore periodic job starts to run on every 9:00 Beijing time.[1] We can now remove the PR triggered event.

This patch remove it.

[1] https://github.com/mindspore-ai/infrastructure/actions