### PR TITLE
Switch to ssh clone style

### DIFF
--- a/.github/workflows/repos-mirror.yml
+++ b/.github/workflows/repos-mirror.yml
@@ -24,4 +24,5 @@ jobs:
         dst_key: ${{ secrets.SYNC_MINDSPORE_PRIVATE_KEY }}
         dst_token:  ${{ secrets.SYNC_MINDSPORE_TOKEN }}
         account_type: org
+        clone_style: ssh 
         static_list: 'mindspore,mindinsight,mindarmour,graphengine,docs,book,community,ms-operator'


### PR DESCRIPTION
Avoid to hit the "port 443: Operation timed out" error, now we switch the clone style to ssh.