### PR TITLE
Remove ktvm option in repos-mirror list

### DIFF
--- a/.github/workflows/repos-mirror.yml
+++ b/.github/workflows/repos-mirror.yml
@@ -25,4 +25,4 @@ jobs:
         dst_token:  ${{ secrets.SYNC_MINDSPORE_TOKEN }}
         account_type: org
         clone_style: ssh 
-        static_list: 'mindspore,mindinsight,mindarmour,graphengine,docs,book,community,ms-operator,akg,ktvm'
+        static_list: 'mindspore,mindinsight,mindarmour,graphengine,docs,book,community,ms-operator,akg'


### PR DESCRIPTION
This  PR is proposed to remove `ktvm` option in repos mirror list, after this merged, the ktvm repo would be removed.