### PR TITLE
Add models to mirror list

### DIFF
--- a/.github/workflows/repos-mirror.yml
+++ b/.github/workflows/repos-mirror.yml
@@ -25,7 +25,7 @@ jobs:
         dst_token:  ${{ secrets.SYNC_MINDSPORE_TOKEN }}
         account_type: org
         clone_style: ssh 
-        static_list: 'mindspore,mindinsight,mindarmour,graphengine,docs,book,community,ms-operator,akg,course,hub,serving,mindquantum,xai'
+        static_list: 'mindspore,mindinsight,mindarmour,graphengine,docs,book,community,ms-operator,akg,course,hub,serving,mindquantum,xai,models'
         force_update: true
         black_list: 'infrastructure'
         debug: true


### PR DESCRIPTION
Add models repo to mirror list, gitee.com/mindspore/models would be mirrored to github periodicly after this merge.